### PR TITLE
Add support for multiple hosts (connections to cluster)

### DIFF
--- a/src/DI/RedisExtension.php
+++ b/src/DI/RedisExtension.php
@@ -28,7 +28,7 @@ final class RedisExtension extends CompilerExtension
 		return Expect::structure([
 			'debug' => Expect::bool(false),
 			'connection' => Expect::arrayOf(Expect::structure([
-				'uri' => Expect::string('tcp://127.0.0.1:6379'),
+				'uri' => Expect::anyOf(Expect::string(), Expect::listOf(Expect::string()))->default('tcp://127.0.0.1:6379'),
 				'options' => Expect::array(),
 				'storage' => Expect::bool(false),
 				'sessions' => Expect::anyOf(


### PR DESCRIPTION
Hi,
we would like to use this package, but we are currently using Redis Sentinel to run Redis in HA.
Predis [has a really nice support for this](https://github.com/predis/predis#replication) (and other replication strategies). The only difference in client instantiation is that
hosts/URIs has to be passed as a list instead of a string with a single host.