### PR TITLE
Add support for multiple hosts (connections to cluster)

### DIFF
--- a/src/DI/RedisExtension.php
+++ b/src/DI/RedisExtension.php
@@ -28,7 +28,7 @@ final class RedisExtension extends CompilerExtension
 		return Expect::structure([
 			'debug' => Expect::bool(false),
 			'connection' => Expect::arrayOf(Expect::structure([
-				'uri' => Expect::string('tcp://127.0.0.1:6379'),
+				'uri' => Expect::anyOf(Expect::string(), Expect::listOf(Expect::string()))->default('tcp://127.0.0.1:6379'),
 				'options' => Expect::array(),
 				'storage' => Expect::bool(false),
 				'sessions' => Expect::anyOf(


### PR DESCRIPTION
This would allow support for [Aggregate Connections](https://github.com/predis/predis#aggregate-connections) such as Redis Sentinel. Everything else is configurable via the current API.