### PR TITLE
serialize data before writing it to redis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,6 @@ tests: vendor
 
 coverage: vendor
 	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./src tests/cases
+
+coverage-html:
+	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.html --coverage-src ./src tests/cases

--- a/tests/cases/RedisStorage.phpt
+++ b/tests/cases/RedisStorage.phpt
@@ -12,7 +12,7 @@ use Tester\Assert;
 require_once __DIR__ . '/../bootstrap.php';
 
 test(function (): void {
-	$storage = (object) [];
+	$storage = (object) ['unserialized' => 'unserialized'];
 
 	$conn = Mockery::mock(ConnectionInterface::class)
 		->shouldReceive('executeCommand')
@@ -36,4 +36,8 @@ test(function (): void {
 	Assert::same('bat', $redis->read('foo'));
 	$redis->remove('foo');
 	Assert::null($redis->read('foo'));
+	Assert::null($redis->read('unserialized'));
+
+	$redis->write('false', false, []);
+	Assert::false($redis->read('false'));
 });


### PR DESCRIPTION
I'm not sure if I did something wrong there, but without this it's not possible to use cache storage and write/read any object/array to redis, which doesn't really sound like expected behaviour?
Whoever installs this and deploy it's  recommended to clear cache first, although if serialization throws exception null should be returned and cache and new data written again...