### PR TITLE
Add interoperability with ENV variables for uri and debug params #23

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -77,3 +77,18 @@ connection:
 		storage: false
 		options: ['parameters': ['database': 1]]
 ```
+
+### Providing configuration from ENV variables
+
+In the need of passing down ENV variables to the configuration you can use `::getenv` on
+`uri` and `debug` parameters, for example:
+
+```neon
+redis:
+	debug: ::getenv('REDIS_DEBUG_MODE')
+	connection:
+		default:
+			uri: ::getenv('REDIS_SERVER_URI')
+```
+
+For `debug` parameter values `true` or `0` (BASH true) will enable the debugging.

--- a/src/DI/RedisExtension.php
+++ b/src/DI/RedisExtension.php
@@ -157,12 +157,12 @@ final class RedisExtension extends CompilerExtension
 			$generator = new PhpGenerator($this->getContainerBuilder());
 			$this->initialization->addBody($generator->formatPhp('?;', [
 				new Statement(
-					'if (strtolower(?) === "true" || ? === "0") { $this->getService(?)->addPanel($this->getService(?)); }'
-					, [
+					'if (strtolower(?) === "true" || ? === "0") { $this->getService(?)->addPanel($this->getService(?)); }',
+					[
 						$config->debug,
 						$config->debug,
 						'tracy.bar',
-						$this->prefix('panel')
+						$this->prefix('panel'),
 					]
 				),
 			]));

--- a/tests/cases/RedisExtension.envConfig.phpt
+++ b/tests/cases/RedisExtension.envConfig.phpt
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Redis;
+
+use Contributte\Redis\DI\RedisExtension;
+use Nette\DI\Config\Loader;
+use Nette\DI\Definitions\Statement;
+use Nette\Schema\Processor;
+use Tester\Assert;
+use Tester\FileMock;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+test(function (): void {
+	putenv('RD_DEBUG=true');
+	putenv('RD_URI=tcp://foo.bar.example:6379');
+
+	$extension = new RedisExtension();
+	$loader = new Loader;
+	$config = $loader->load(FileMock::create('
+	debug: ::getenv("RD_DEBUG")
+	connection:
+		default:
+			uri: ::getenv("RD_URI")
+			sessions: true
+			storage: false
+			options: []
+	', 'neon'));
+
+	$processor = new Processor();
+	$schema = $extension->getConfigSchema();
+	$normalized = $processor->process($schema, $config);
+
+	Assert::type(Statement::class, $normalized->debug);
+	Assert::type(Statement::class, $normalized->connection['default']->uri);
+	Assert::equal([], $normalized->connection['default']->options);
+
+	putenv('RD_DEBUG=');
+	putenv('RD_URI=');
+});

--- a/tests/cases/RedisExtension.envConfig.phpt
+++ b/tests/cases/RedisExtension.envConfig.phpt
@@ -16,7 +16,7 @@ test(function (): void {
 	putenv('RD_URI=tcp://foo.bar.example:6379');
 
 	$extension = new RedisExtension();
-	$loader = new Loader;
+	$loader = new Loader();
 	$config = $loader->load(FileMock::create('
 	debug: ::getenv("RD_DEBUG")
 	connection:

--- a/tests/cases/RedisExtension.integration.phpt
+++ b/tests/cases/RedisExtension.integration.phpt
@@ -1,0 +1,153 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Redis;
+
+use Contributte\Redis\Tracy\RedisPanel;
+use Nette\DI\Compiler;
+use Nette\DI\Config\Loader;
+use Nette\DI\Container;
+use Nette\DI\ContainerBuilder;
+use Nette\DI\Extensions\ExtensionsExtension;
+use Nette\DI\PhpGenerator;
+use Predis\Client;
+use Predis\Connection\ConnectionException;
+use Tester\Assert;
+use Tester\FileMock;
+use Tracy\Bar;
+use Tracy\Bridges\Nette\TracyExtension;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+function createContainer($source, $config = null, array $params = []): ?Container
+{
+	$class = 'Container' . md5((string) lcg_value());
+	if ($source instanceof ContainerBuilder) {
+		$source->complete();
+		$code = (new PhpGenerator($source))->generate($class);
+
+	} elseif ($source instanceof Compiler) {
+		if (is_string($config)) {
+			$loader = new Loader;
+			$config = $loader->load(is_file($config) ? $config : FileMock::create($config, 'neon'));
+		}
+		$code = $source->addConfig((array) $config)
+			->setClassName($class)
+			->compile();
+	} else {
+		return null;
+	}
+
+	file_put_contents(__DIR__ . '/../tmp/code.php', "<?php\n\n$code");
+	require __DIR__ . '/../tmp/code.php';
+	return new $class($params);
+}
+
+
+test(function (): void {
+	putenv('RD_DEBUG=1');
+	putenv('RD_URI=tcp://foo.bar.example:6379s');
+
+
+	$compiler = new Compiler;
+	$compiler->addExtension('tracy', new TracyExtension());
+	$compiler->addExtension('extensions', new ExtensionsExtension);
+	$container = createContainer($compiler, '
+services:
+- \Nette\Caching\Storages\DevNullStorage
+- \Nette\Http\Session
+- \Nette\Http\Request
+- \Nette\Http\Response
+- \Nette\Http\UrlScript
+
+extensions:
+	redis: Contributte\Redis\DI\RedisExtension
+
+tracy:
+	showBar: true
+
+redis:
+	debug: ::getenv("RD_DEBUG")
+	connection:
+		default:
+			uri: ::getenv("RD_URI")
+			sessions: true
+			storage: false
+			options: []
+');
+	// Call container initiation to properly test whether RedisPanel is given to Tracy bar or not
+	// Panel can be registered (as this cannot be easily prevented) but should not be registered in the bar.
+	$container->initialize();
+	Assert::notNull($container->getByType(RedisPanel::class));
+
+	/** @var Bar|mixed|null $bar */
+	$bar = $container->getByType(Bar::class);
+	Assert::notNull($bar);
+	Assert::type(Bar::class, $bar);
+	$redisPanelInBar = $bar->getPanel(RedisPanel::class);
+	Assert::null($redisPanelInBar);
+
+	/** @var Client|mixed|null $client */
+	$client = $container->getByName('redis.connection.default.client');
+	$client2 = $container->getByType(Client::class);
+	Assert::notNull($client);
+	Assert::notNull($client2);
+	Assert::type(Client::class, $client);
+	Assert::type(Client::class, $client2);
+	Assert::same($client, $client2);
+	try {
+		$client->connect();
+		Assert::fail('Connect is expected to fail');
+	} catch (ConnectionException $e) {
+		Assert::equal('php_network_getaddresses: getaddrinfo failed: nodename nor servname provided, or not known [tcp://foo.bar.example:6379]', $e->getMessage());
+	} finally {
+		putenv('RD_DEBUG=');
+		putenv('RD_URI=');
+	}
+});
+
+test(function (): void {
+	putenv('RD_DEBUG=0');
+	putenv('RD_URI=tcp://foo.bar.example:6379s');
+
+
+	$compiler = new Compiler;
+	$compiler->addExtension('tracy', new TracyExtension());
+	$compiler->addExtension('extensions', new ExtensionsExtension);
+	$container = createContainer($compiler, '
+services:
+- \Nette\Caching\Storages\DevNullStorage
+- \Nette\Http\Session
+- \Nette\Http\Request
+- \Nette\Http\Response
+- \Nette\Http\UrlScript
+
+extensions:
+	redis: Contributte\Redis\DI\RedisExtension
+
+tracy:
+	showBar: true
+
+redis:
+	debug: ::getenv("RD_DEBUG")
+	connection:
+		default:
+			uri: ::getenv("RD_URI")
+			sessions: true
+			storage: false
+			options: []
+');
+	// Call container initiation to properly test whether RedisPanel is given to Tracy bar or not
+	// Panel can be registered (as this cannot be easily prevented) but should not be registered in the bar.
+	$container->initialize();
+	Assert::notNull($container->getByType(RedisPanel::class));
+
+	/** @var Bar|mixed|null $bar */
+	$bar = $container->getByType(Bar::class);
+	Assert::notNull($bar);
+	Assert::type(Bar::class, $bar);
+	$redisPanelInBar = $bar->getPanel(RedisPanel::class);
+	Assert::notNull($redisPanelInBar);
+
+	putenv('RD_DEBUG=');
+	putenv('RD_URI=');
+});

--- a/tests/cases/RedisExtension.scalarConfig.phpt
+++ b/tests/cases/RedisExtension.scalarConfig.phpt
@@ -12,7 +12,7 @@ require_once __DIR__ . '/../bootstrap.php';
 
 test(function (): void {
 	$extension = new RedisExtension();
-	$loader = new Loader;
+	$loader = new Loader();
 	$config = $loader->load(FileMock::create('
 	debug: false
 	connection:

--- a/tests/cases/RedisExtension.scalarConfig.phpt
+++ b/tests/cases/RedisExtension.scalarConfig.phpt
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Redis;
+
+use Contributte\Redis\DI\RedisExtension;
+use Nette\DI\Config\Loader;
+use Nette\Schema\Processor;
+use Tester\Assert;
+use Tester\FileMock;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+test(function (): void {
+	$extension = new RedisExtension();
+	$loader = new Loader;
+	$config = $loader->load(FileMock::create('
+	debug: false
+	connection:
+		default:
+			uri: "tcp://foo.bar.example:6379"
+			sessions: false
+			storage: true
+			options: ["parameters": ["database": 1]]
+	', 'neon'));
+
+	$processor = new Processor();
+	$schema = $extension->getConfigSchema();
+	$normalized = $processor->process($schema, $config);
+
+	Assert::equal(false, $normalized->debug);
+	Assert::equal('tcp://foo.bar.example:6379', $normalized->connection['default']->uri);
+	Assert::equal(false, $normalized->connection['default']->sessions);
+	Assert::equal(true, $normalized->connection['default']->storage);
+	Assert::equal(['parameters' => ['database' => 1]], $normalized->connection['default']->options);
+});


### PR DESCRIPTION
Currently done for uri (most important) and debug (also quite important) params, others were tried but as the passthrough of the other parameters is done at compile time it was not done, because it would be incoherent with the evaluation of uri and debug params -- they are evaluated during runtime.

Due to this issue the panel is registered but is at runtime not included in tracy when debug mode is not enabled.