### PR TITLE
Fixed DI: Creating journal only if really needed

### DIFF
--- a/src/DI/RedisExtension.php
+++ b/src/DI/RedisExtension.php
@@ -48,8 +48,6 @@ final class RedisExtension extends CompilerExtension
 
 		$connections = [];
 
-		$builder->addDefinition($this->prefix('journal'))->setType(RedisJournal::class);
-
 		foreach ($config->connection as $name => $connection) {
 			$client = $builder->addDefinition($this->prefix('connection.' . $name . '.client'))
 				->setType(Client::class)
@@ -98,8 +96,16 @@ final class RedisExtension extends CompilerExtension
 			$builder->getDefinitionByType(IStorage::class)
 				->setAutowired(false);
 
+			$builder->addDefinition($this->prefix('connection.' . $name . 'journal'))
+				->setFactory(RedisJournal::class)
+				->setAutowired(false);
+
 			$builder->addDefinition($this->prefix('connection.' . $name . 'storage'))
-				->setFactory(RedisStorage::class);
+				->setFactory(RedisStorage::class)
+				->setArguments([
+					'journal' => $builder->getDefinition($this->prefix('connection.' . $name . 'journal')),
+					'serializer' => $config->serializer,
+				]);
 		}
 	}
 

--- a/src/DI/RedisExtension24.php
+++ b/src/DI/RedisExtension24.php
@@ -49,8 +49,6 @@ final class RedisExtension24 extends CompilerExtension
 
 		$connections = [];
 
-		$builder->addDefinition($this->prefix('journal'))->setType(RedisJournal::class)->setAutowired(false);
-
 		foreach ($config['connection'] as $name => $connection) {
 			$connection = $this->validateConfig($this->connectionDefaults, $connection, $this->prefix('connection.' . $name));
 
@@ -103,10 +101,14 @@ final class RedisExtension24 extends CompilerExtension
 			$builder->getDefinitionByType(IStorage::class)
 				->setAutowired(false);
 
+			$builder->addDefinition($this->prefix('connection.' . $name . 'journal'))
+				->setFactory(RedisJournal::class)
+				->setAutowired(false);
+
 			$builder->addDefinition($this->prefix('connection.' . $name . 'storage'))
 				->setFactory(RedisStorage::class)
 				->setArguments([
-					'journal' => $builder->getDefinition($this->prefix('journal')),
+					'journal' => $builder->getDefinition($this->prefix('connection.' . $name . 'journal')),
 					'serializer' => $config['serializer'],
 				])
 				->setAutowired(true);


### PR DESCRIPTION
In case someone use Redis without storage, it still try to create Journal class and failed badly. This patch update DI to create journal for each storage and only when requested. There can be one more update later, to skip journal even if Storage is used (will result on exceptions when tried to run some Journal required stuff)