### PR TITLE
Fixed nette/caching namespace separator

### DIFF
--- a/src/Caching/RedisStorage.php
+++ b/src/Caching/RedisStorage.php
@@ -159,7 +159,7 @@ final class RedisStorage implements Storage
 		}
 
 		$data = $this->serializer->serialize($data, $meta);
-		$store = json_encode($meta) . Cache::NAMESPACE_SEPARATOR . $data;
+		$store = json_encode($meta) . Cache::NamespaceSeparator . $data;
 
 		try {
 			if (isset($dependencies[Cache::EXPIRATION])) {
@@ -209,7 +209,7 @@ final class RedisStorage implements Storage
 
 	private function formatEntryKey(string $key): string
 	{
-		return self::NS_NETTE . ':' . str_replace(Cache::NAMESPACE_SEPARATOR, ':', $key);
+		return self::NS_NETTE . ':' . str_replace(Cache::NamespaceSeparator, ':', $key);
 	}
 
 
@@ -312,7 +312,7 @@ final class RedisStorage implements Storage
 	 */
 	private static function processStoredValue(string $key, string $storedValue): array
 	{
-		[$meta, $data] = explode(Cache::NAMESPACE_SEPARATOR, $storedValue, 2) + [null, null];
+		[$meta, $data] = explode(Cache::NamespaceSeparator, $storedValue, 2) + [null, null];
 		return [[self::KEY => $key] + json_decode((string) $meta, true), $data];
 	}
 


### PR DESCRIPTION
Fixes this BC break
https://github.com/nette/caching/commit/8bf7455878eca4ce74083d0fc52b722e6c89ff51#diff-c3abbeb8a7d04b072c4f38e38e10d763123f5503f1719f852ec21e1602c4c4dbL37