### PR TITLE
Fix compatibility with Nette/Caching v3.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   },
   "require-dev": {
     "mockery/mockery": "^1.3.3",
-    "nette/caching": "^2.5.0 || ^3.1.0",
+    "nette/caching": "^2.5.0 || ^3.1.3",
     "nette/http": "^2.4.0 || ^3.0.1",
     "ninjify/nunjuck": "^0.4",
     "ninjify/qa": "^0.12",

--- a/src/Caching/RedisStorage.php
+++ b/src/Caching/RedisStorage.php
@@ -18,6 +18,7 @@ final class RedisStorage implements Storage
 {
 
 	private const NS_NETTE = 'Contributte.Storage';
+	private const NAMESPACE_SEPARATOR = "\x00";
 
 	private const META_TIME = 'time'; // timestamp
 	private const META_EXPIRE = 'expire'; // expiration timestamp
@@ -159,7 +160,7 @@ final class RedisStorage implements Storage
 		}
 
 		$data = $this->serializer->serialize($data, $meta);
-		$store = json_encode($meta) . Cache::NAMESPACE_SEPARATOR . $data;
+		$store = json_encode($meta) . self::NAMESPACE_SEPARATOR . $data;
 
 		try {
 			if (isset($dependencies[Cache::EXPIRATION])) {
@@ -209,7 +210,7 @@ final class RedisStorage implements Storage
 
 	private function formatEntryKey(string $key): string
 	{
-		return self::NS_NETTE . ':' . str_replace(Cache::NAMESPACE_SEPARATOR, ':', $key);
+		return self::NS_NETTE . ':' . str_replace(self::NAMESPACE_SEPARATOR, ':', $key);
 	}
 
 
@@ -312,7 +313,7 @@ final class RedisStorage implements Storage
 	 */
 	private static function processStoredValue(string $key, string $storedValue): array
 	{
-		[$meta, $data] = explode(Cache::NAMESPACE_SEPARATOR, $storedValue, 2) + [null, null];
+		[$meta, $data] = explode(self::NAMESPACE_SEPARATOR, $storedValue, 2) + [null, null];
 		return [[self::KEY => $key] + json_decode((string) $meta, true), $data];
 	}
 

--- a/src/Caching/RedisStorage.php
+++ b/src/Caching/RedisStorage.php
@@ -18,7 +18,7 @@ final class RedisStorage implements Storage
 {
 
 	private const NS_NETTE = 'Contributte.Storage';
-	private const NAMESPACE_SEPARATOR = "\x00";
+	private const NS_SEPARATOR = "\x00";
 
 	private const META_TIME = 'time'; // timestamp
 	private const META_EXPIRE = 'expire'; // expiration timestamp
@@ -160,7 +160,7 @@ final class RedisStorage implements Storage
 		}
 
 		$data = $this->serializer->serialize($data, $meta);
-		$store = json_encode($meta) . self::NAMESPACE_SEPARATOR . $data;
+		$store = json_encode($meta) . self::NS_SEPARATOR . $data;
 
 		try {
 			if (isset($dependencies[Cache::EXPIRATION])) {
@@ -210,7 +210,7 @@ final class RedisStorage implements Storage
 
 	private function formatEntryKey(string $key): string
 	{
-		return self::NS_NETTE . ':' . str_replace(self::NAMESPACE_SEPARATOR, ':', $key);
+		return self::NS_NETTE . ':' . str_replace(self::NS_SEPARATOR, ':', $key);
 	}
 
 
@@ -313,7 +313,7 @@ final class RedisStorage implements Storage
 	 */
 	private static function processStoredValue(string $key, string $storedValue): array
 	{
-		[$meta, $data] = explode(self::NAMESPACE_SEPARATOR, $storedValue, 2) + [null, null];
+		[$meta, $data] = explode(self::NS_SEPARATOR, $storedValue, 2) + [null, null];
 		return [[self::KEY => $key] + json_decode((string) $meta, true), $data];
 	}
 


### PR DESCRIPTION
- at last version of Nette/Caching https://github.com/nette/caching/releases/tag/v3.1.3 was changed name of constant `NAMESPACE_SEPARATOR` to `NamespaceSeparator`
- because constant is **internal**, i moved it to RedisStorage class