### PR TITLE
add option to declare redis client factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,10 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   },
   "extra": {
     "branch-alias": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,5 +8,37 @@ parameters:
 		- src/DI/RedisExtension24.php
 
 	ignoreErrors:
-		- '#Function snappy_(.+) not found.#'
 		- "#^Do\\-while loop condition is always false\\.$#"
+
+		# backward compatibility with nette/caching < 3.1
+		-
+			message: """
+				#^Class Contributte\\\\Redis\\\\Caching\\\\RedisJournal implements deprecated interface Nette\\\\Caching\\\\Storages\\\\IJournal\\:
+				use Nette\\\\Caching\\\\Storages\\\\Journal$#
+			"""
+			count: 1
+			path: src/Caching/RedisJournal.php
+
+		-
+			message: """
+				#^Class Contributte\\\\Redis\\\\Caching\\\\RedisStorage implements deprecated interface Nette\\\\Caching\\\\IStorage\\:
+				use Nette\\\\Caching\\\\Storage$#
+			"""
+			count: 1
+			path: src/Caching/RedisStorage.php
+
+		-
+			message: """
+				#^Parameter \\$journal of method Contributte\\\\Redis\\\\Caching\\\\RedisStorage\\:\\:__construct\\(\\) has typehint with deprecated interface Nette\\\\Caching\\\\Storages\\\\IJournal\\:
+				use Nette\\\\Caching\\\\Storages\\\\Journal$#
+			"""
+			count: 1
+			path: src/Caching/RedisStorage.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Nette\\\\Caching\\\\IStorage\\:
+				use Nette\\\\Caching\\\\Storage$#
+			"""
+			count: 3
+			path: src/DI/RedisExtension.php

--- a/src/Caching/RedisJournal.php
+++ b/src/Caching/RedisJournal.php
@@ -4,7 +4,7 @@ namespace Contributte\Redis\Caching;
 
 use Nette\Caching\Cache;
 use Nette\Caching\Storages\IJournal as Journal;
-use Predis\Client;
+use Predis\ClientInterface;
 
 /**
  * @see based on original https://github.com/Kdyby/Redis
@@ -18,13 +18,10 @@ final class RedisJournal implements Journal
 	private const TAGS = 'tags';
 	private const KEYS = 'keys';
 
-	/** @var Client<mixed> */
+	/** @var ClientInterface $client */
 	private $client;
 
-	/**
-	 * @param Client<mixed> $client
-	 */
-	public function __construct(Client $client)
+	public function __construct(ClientInterface $client)
 	{
 		$this->client = $client;
 	}

--- a/src/Caching/RedisStorage.php
+++ b/src/Caching/RedisStorage.php
@@ -295,7 +295,7 @@ final class RedisStorage implements Storage
 		$formattedKeys = array_map([$this, 'formatEntryKey'], $keys);
 
 		$result = [];
-		foreach ($this->client->mget([$formattedKeys]) as $index => $stored) {
+		foreach ($this->client->mget($formattedKeys) as $index => $stored) {
 			$key = $keys[$index];
 			$result[$key] = $stored !== false ? self::processStoredValue($key, $stored) : null;
 		}

--- a/src/Caching/RedisStorage.php
+++ b/src/Caching/RedisStorage.php
@@ -8,7 +8,7 @@ use Nette\Caching\Cache;
 use Nette\Caching\IStorage as Storage;
 use Nette\Caching\Storages\IJournal as Journal;
 use Nette\InvalidStateException;
-use Predis\Client;
+use Predis\ClientInterface;
 use Predis\PredisException;
 
 /**
@@ -27,7 +27,7 @@ final class RedisStorage implements Storage
 	private const META_CALLBACKS = 'callbacks'; // array of callbacks (function, args)
 	private const KEY = 'key'; // additional cache structure
 
-	/** @var Client<mixed> $client */
+	/** @var ClientInterface $client */
 	private $client;
 
 	/** @var Journal|null $journal */
@@ -37,11 +37,11 @@ final class RedisStorage implements Storage
 	private $serializer;
 
 	/**
-	 * @param Client<mixed> $client
+	 * @param ClientInterface $client
 	 * @param Journal|null $journal
 	 * @param Serializer|null $serializer
 	 */
-	public function __construct(Client $client, ?Journal $journal = null, ?Serializer $serializer = null)
+	public function __construct(ClientInterface $client, ?Journal $journal = null, ?Serializer $serializer = null)
 	{
 		$this->client = $client;
 		$this->journal = $journal;
@@ -53,10 +53,7 @@ final class RedisStorage implements Storage
 		$this->serializer = $serializer;
 	}
 
-	/**
-	 * @return Client<mixed>
-	 */
-	public function getClient(): Client
+	public function getClient(): ClientInterface
 	{
 		return $this->client;
 	}

--- a/src/DI/RedisExtension.php
+++ b/src/DI/RedisExtension.php
@@ -14,6 +14,7 @@ use Nette\PhpGenerator\ClassType;
 use Nette\Schema\Expect;
 use Nette\Schema\Schema;
 use Predis\Client;
+use Predis\ClientInterface;
 use Predis\Session\Handler;
 use RuntimeException;
 use stdClass;
@@ -38,6 +39,7 @@ final class RedisExtension extends CompilerExtension
 					Expect::array()
 				)->default(false),
 			])),
+			'clientFactory' => Expect::string(Client::class),
 		]);
 	}
 
@@ -52,8 +54,8 @@ final class RedisExtension extends CompilerExtension
 			$autowired = $name === 'default';
 
 			$client = $builder->addDefinition($this->prefix('connection.' . $name . '.client'))
-				->setType(Client::class)
-				->setArguments([$connection->uri, $connection->options])
+				->setType(ClientInterface::class)
+				->setFactory($config->clientFactory, [$connection->uri, $connection->options])
 				->setAutowired($autowired);
 
 			$connections[] = [

--- a/src/DI/RedisExtension24.php
+++ b/src/DI/RedisExtension24.php
@@ -23,6 +23,7 @@ final class RedisExtension24 extends CompilerExtension
 		'debug' => false,
 		'serializer' => null,
 		'connection' => [],
+		'clientFactory' => Client::class,
 	];
 
 	/** @var mixed[] */
@@ -54,8 +55,8 @@ final class RedisExtension24 extends CompilerExtension
 			$connection = $this->validateConfig($this->connectionDefaults, $connection, $this->prefix('connection.' . $name));
 
 			$client = $builder->addDefinition($this->prefix('connection.' . $name . '.client'))
-				->setType(Client::class)
-				->setArguments([$connection['uri'], $connection['options']])
+				->setType(ClientInterface::class)
+				->setFactory($config['clientFactory'], [$connection['uri'], $connection['options']])
 				->setAutowired($autowired);
 
 			$connections[] = [

--- a/src/Serializer/SnappySerializer.php
+++ b/src/Serializer/SnappySerializer.php
@@ -10,7 +10,7 @@ final class SnappySerializer implements Serializer
 	 */
 	public function serialize($data, array &$meta): string
 	{
-		return @snappy_compress(json_encode($data));
+		return @snappy_compress(json_encode($data)); // @phpstan-ignore-line
 	}
 
 	/**
@@ -18,7 +18,7 @@ final class SnappySerializer implements Serializer
 	 */
 	public function unserialize(string $data, array $meta)
 	{
-		return json_decode(@snappy_uncompress($data));
+		return json_decode(@snappy_uncompress($data)); // @phpstan-ignore-line
 	}
 
 }

--- a/tests/cases/DI/RedisExtension.phpt
+++ b/tests/cases/DI/RedisExtension.phpt
@@ -164,3 +164,28 @@ Toolkit::test(function (): void {
 	Assert::equal('1.2.3.4', $parameters['host']);
 	Assert::equal(1234, $parameters['port']);
 });
+
+// phpcs:ignore
+class RedisClient extends Client {}
+
+// Client factory
+Toolkit::test(function (): void {
+	$container = Container::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('redis', new RedisExtension());
+			$compiler->addExtension('caching', new CacheExtension(Tests::TEMP_PATH));
+			$compiler->addConfig(Helpers::neon('
+				redis:
+					clientFactory: Tests\Cases\DI\RedisClient
+					connection:
+						default:
+							uri: tcp://127.0.0.1:1111
+							storage: true
+			'));
+		})
+		->build();
+
+	$client = $container->getService('redis.connection.default.client');
+
+	Assert::type(RedisClient::class, $client);
+});


### PR DESCRIPTION
Adds option to declare custom `Predis\ClientInterface` factory. It may be useful when you need to decorate/extend the client.