### PR TITLE
fix missing namespace in RedisExtension24

### DIFF
--- a/src/DI/RedisExtension24.php
+++ b/src/DI/RedisExtension24.php
@@ -12,6 +12,7 @@ use Nette\Http\Session;
 use Nette\PhpGenerator\ClassType;
 use Nette\Utils\Validators;
 use Predis\Client;
+use Predis\ClientInterface;
 use Predis\Session\Handler;
 use RuntimeException;
 


### PR DESCRIPTION
Hi, by my last pr https://github.com/contributte/redis/pull/41 I caused a bug, which brokes RedisExtension24 (extension cannot be even compiled). I'm sorry, there is a fix.