### PR TITLE
Allow dynamic string list for uri config

### DIFF
--- a/src/DI/RedisExtension.php
+++ b/src/DI/RedisExtension.php
@@ -31,7 +31,7 @@ final class RedisExtension extends CompilerExtension
 			'debug' => Expect::bool(false),
 			'serializer' => Expect::anyOf(Expect::string()),
 			'connection' => Expect::arrayOf(Expect::structure([
-				'uri' => Expect::anyOf(Expect::string(), Expect::listOf(Expect::string()))->default('tcp://127.0.0.1:6379')->dynamic(),
+				'uri' => Expect::anyOf(Expect::string()->dynamic(), Expect::listOf(Expect::string()->dynamic()))->default('tcp://127.0.0.1:6379'),
 				'options' => Expect::array(),
 				'storageClass' => Expect::string()->default(RedisStorage::class),
 				'storage' => Expect::bool(false),


### PR DESCRIPTION
Current config schema does not accept dynamic parameters when using multiple URI for replication:
```php
uri: [
	'tcp://%SECRETS_REDIS_HOST?role=master',
	'tcp://%SECRETS_REDIS_HOST_READ_REPLICA%,
]
```

This change is backwards compatible.