### PR TITLE
Fix "priority" dependency

### DIFF
--- a/src/Caching/RedisJournal.php
+++ b/src/Caching/RedisJournal.php
@@ -47,7 +47,7 @@ final class RedisJournal implements Journal
 		}
 
 		if (isset($dependencies[Cache::PRIORITY])) {
-			$this->client->zadd($this->formatKey(self::PRIORITY), $dependencies[Cache::PRIORITY]);
+			$this->client->zadd($this->formatKey(self::PRIORITY), [$key => $dependencies[Cache::PRIORITY]]);
 		}
 
 		$this->client->exec();

--- a/src/Caching/RedisJournal.php
+++ b/src/Caching/RedisJournal.php
@@ -69,7 +69,7 @@ final class RedisJournal implements Journal
 			}
 
 			// drop tags of entry and priority, in case there are some
-			$this->client->del([$this->formatKey($key, self::TAGS), $this->formatKey($key, self::PRIORITY)]);
+			$this->client->del($this->formatKey($key, self::TAGS));
 			$this->client->zrem($this->formatKey(self::PRIORITY), $key);
 
 			$this->client->exec();

--- a/tests/Cases/E2E/Predis.phpt
+++ b/tests/Cases/E2E/Predis.phpt
@@ -99,3 +99,33 @@ Toolkit::test(function () use ($cache): void {
 	sleep(2);
 	Assert::equal(null, $cache->load('foo'));
 });
+
+// Priority
+Toolkit::test(function () use ($cache): void {
+	$cache->save('foo1', 'bar1', [Cache::PRIORITY => 40]);
+	$cache->save('foo2', 'bar2', [Cache::PRIORITY => 30]);
+	$cache->save('foo3', 'bar3', [Cache::PRIORITY => 20]);
+	$cache->save('foo4', 'bar4', [Cache::PRIORITY => 10]);
+	Assert::same('bar1', $cache->load('foo1'));
+	Assert::same('bar2', $cache->load('foo2'));
+	Assert::same('bar3', $cache->load('foo3'));
+	Assert::same('bar4', $cache->load('foo4'));
+
+	$cache->clean([Cache::PRIORITY => 10]);
+	Assert::same('bar1', $cache->load('foo1'));
+	Assert::same('bar2', $cache->load('foo2'));
+	Assert::same('bar3', $cache->load('foo3'));
+	Assert::same(null, $cache->load('foo4'));
+
+	$cache->clean([Cache::PRIORITY => 30]);
+	Assert::same('bar1', $cache->load('foo1'));
+	Assert::same(null, $cache->load('foo2'));
+	Assert::same(null, $cache->load('foo3'));
+	Assert::same(null, $cache->load('foo4'));
+
+	$cache->clean([Cache::PRIORITY => 100]);
+	Assert::same(null, $cache->load('foo1'));
+	Assert::same(null, $cache->load('foo2'));
+	Assert::same(null, $cache->load('foo3'));
+	Assert::same(null, $cache->load('foo4'));
+});


### PR DESCRIPTION
Without this PR, the extensions fails with Redis error `ERR wrong number of arguments for 'zadd' command ` when using [priority dependency](https://doc.nette.org/cs/caching#toc-invalidace-pomoci-priority).