### PR TITLE
Remove tags for removed key

### DIFF
--- a/src/Caching/RedisJournal.php
+++ b/src/Caching/RedisJournal.php
@@ -58,7 +58,7 @@ final class RedisJournal implements Journal
 	 *
 	 * @param mixed[]|string $keys
 	 */
-	private function cleanEntry($keys): void
+	public function cleanEntry($keys): void
 	{
 		foreach (is_array($keys) ? $keys : [$keys] as $key) {
 			$entries = $this->entryTags($key);

--- a/src/Caching/RedisStorage.php
+++ b/src/Caching/RedisStorage.php
@@ -82,6 +82,10 @@ final class RedisStorage implements Storage
 	public function remove($key): void
 	{
 		$this->client->del([$this->formatEntryKey($key)]);
+
+		if ($this->journal instanceof RedisJournal) {
+			$this->journal->cleanEntry($this->formatEntryKey($key));
+		}
 	}
 
 	/**

--- a/src/Caching/RedisStorage.php
+++ b/src/Caching/RedisStorage.php
@@ -17,7 +17,7 @@ use Predis\PredisException;
 final class RedisStorage implements Storage
 {
 
-	private const NS_NETTE = 'Contributte.Storage';
+	public const NS_PREFIX = 'Contributte.Storage';
 	private const NS_SEPARATOR = "\x00";
 
 	private const META_TIME = 'time'; // timestamp
@@ -211,7 +211,7 @@ final class RedisStorage implements Storage
 
 	private function formatEntryKey(string $key): string
 	{
-		return self::NS_NETTE . ':' . str_replace(self::NS_SEPARATOR, ':', $key);
+		return self::NS_PREFIX . ':' . str_replace(self::NS_SEPARATOR, ':', $key);
 	}
 
 

--- a/tests/Cases/E2E/Predis.phpt
+++ b/tests/Cases/E2E/Predis.phpt
@@ -131,33 +131,34 @@ Toolkit::test(function () use ($cache): void {
 });
 
 // Helper function for journal related tests
-$generateJournalKey = static function (?string $storageKey, ?string $journalPart): string {
-	return ($storageKey ? 'Contributte.Journal:Contributte.Storage:' . $storageKey : 'Contributte.Journal') . ($journalPart ? ':' . $journalPart : null);
+$generateJournalKey = static function (string $key, string $suffix, bool $addStoragePrefix): string {
+	$prefix = $addStoragePrefix ? sprintf('%s:%s', RedisJournal::NS_PREFIX, RedisStorage::NS_PREFIX) : RedisJournal::NS_PREFIX;
+	return sprintf('%s:%s:%s', $prefix, $key, $suffix);
 };
 
 // Tags cleaning
 Toolkit::test(function () use ($storage, $client, $generateJournalKey): void {
 	$storage->clean([Cache::ALL => true]);
-	Assert::same(0, $client->exists($generateJournalKey(null, 'tag:keys')));
+	Assert::same(0, $client->exists($generateJournalKey('tag', RedisJournal::SUFFIX_KEYS, false)));
 
 	$storage->write('foo', 'bar', [Cache::TAGS => ['tag']]);
-	Assert::same(1, $client->exists($generateJournalKey('foo', 'tags')));
-	Assert::same(1, $client->exists($generateJournalKey(null, 'tag:keys')));
+	Assert::same(1, $client->exists($generateJournalKey('foo', RedisJournal::SUFFIX_TAGS, true)));
+	Assert::same(1, $client->exists($generateJournalKey('tag', RedisJournal::SUFFIX_KEYS, false)));
 	$storage->clean([Cache::TAGS => ['tag']]);
-	Assert::same(0, $client->exists($generateJournalKey('foo', 'tags')));
-	Assert::same(0, $client->exists($generateJournalKey(null, 'tag:keys')));
+	Assert::same(0, $client->exists($generateJournalKey('foo', RedisJournal::SUFFIX_TAGS, true)));
+	Assert::same(0, $client->exists($generateJournalKey('tag', RedisJournal::SUFFIX_KEYS, false)));
 
 	$storage->write('foo', 'bar', [Cache::TAGS => ['tag']]);
-	Assert::same(1, $client->exists($generateJournalKey('foo', 'tags')));
-	Assert::same(1, $client->exists($generateJournalKey(null, 'tag:keys')));
+	Assert::same(1, $client->exists($generateJournalKey('foo', RedisJournal::SUFFIX_TAGS, true)));
+	Assert::same(1, $client->exists($generateJournalKey('tag', RedisJournal::SUFFIX_KEYS, false)));
 	$storage->remove('foo');
-	Assert::same(0, $client->exists($generateJournalKey('foo', 'tags')));
-	Assert::same(0, $client->exists($generateJournalKey(null, 'tag:keys')));
+	Assert::same(0, $client->exists($generateJournalKey('foo', RedisJournal::SUFFIX_TAGS, true)));
+	Assert::same(0, $client->exists($generateJournalKey('tag', RedisJournal::SUFFIX_KEYS, false)));
 
 	$storage->write('foo', 'bar', [Cache::TAGS => ['tag'], Cache::PRIORITY => 1]);
-	Assert::same(1, $client->exists($generateJournalKey('foo', 'tags')));
-	Assert::same(1, $client->exists($generateJournalKey(null, 'tag:keys')));
+	Assert::same(1, $client->exists($generateJournalKey('foo', RedisJournal::SUFFIX_TAGS, true)));
+	Assert::same(1, $client->exists($generateJournalKey('tag', RedisJournal::SUFFIX_KEYS, false)));
 	$storage->clean([Cache::PRIORITY => 1]);
-	Assert::same(0, $client->exists($generateJournalKey('foo', 'tags')));
-	Assert::same(0, $client->exists($generateJournalKey(null, 'tag:keys')));
+	Assert::same(0, $client->exists($generateJournalKey('foo', RedisJournal::SUFFIX_TAGS, true)));
+	Assert::same(0, $client->exists($generateJournalKey('tag', RedisJournal::SUFFIX_KEYS, false)));
 });


### PR DESCRIPTION
This change removes associated `<key>:tags` entry when calling

```php
$storage->remove('<key>');
```

Also it makes naming constants public so they can be reused in tests. This can be removed from the PR if that causes some problem.

Tests need #53 to pass.